### PR TITLE
Fix missing options in nvim_exec2 calls

### DIFF
--- a/lua/cosco/filetypes/matlab.lua
+++ b/lua/cosco/filetypes/matlab.lua
@@ -14,9 +14,9 @@ M.parse = function()
     -- do nothing: it's an "end"
   elseif vim.b.current_line_last_char == ";" then
     -- toggle semicolon
-    vim.api.nvim_exec2("s/;$//")
+    vim.api.nvim_exec2("s/;$//", {})
   else
-    vim.api.nvim_exec2("s/$/;/")
+    vim.api.nvim_exec2("s/$/;/", {})
   end
 end
 

--- a/lua/cosco/filetypes/octave.lua
+++ b/lua/cosco/filetypes/octave.lua
@@ -14,9 +14,9 @@ M.parse = function()
     -- do nothing: it's an "end"
   elseif vim.b.current_line_last_char == ";" then
     -- toggle semicolon
-    vim.api.nvim_exec2("s/;$//")
+    vim.api.nvim_exec2("s/;$//", {})
   else
-    vim.api.nvim_exec2("s/$/;/")
+    vim.api.nvim_exec2("s/$/;/", {})
   end
 end
 


### PR DESCRIPTION
## Summary
- fix missing dictionary argument to `nvim_exec2` in Matlab and Octave filetype helpers

## Testing
- `make test` *(fails: `nvim` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaa6b5b5c832ca8ddfd22e2df5f30